### PR TITLE
Fix dupe & change potion color

### DIFF
--- a/src/main/java/pepjebs/craftablepotioncombinations/recipe/CraftablePotionCombinationCraftingRecipe.java
+++ b/src/main/java/pepjebs/craftablepotioncombinations/recipe/CraftablePotionCombinationCraftingRecipe.java
@@ -23,7 +23,8 @@ public class CraftablePotionCombinationCraftingRecipe extends SpecialCraftingRec
 
     @Override
     public boolean matches(CraftingInventory inventory, World world) {
-        return !inventory.containsAny(p -> !p.isOf(Items.POTION) && !p.isEmpty());
+        return inventory.containsAny(p -> p.isOf(Items.POTION) && !p.isEmpty())
+                && !inventory.containsAny(p -> !p.isOf(Items.POTION) && !p.isEmpty());
     }
 
     @Override

--- a/src/main/java/pepjebs/craftablepotioncombinations/recipe/CraftablePotionCombinationCraftingRecipe.java
+++ b/src/main/java/pepjebs/craftablepotioncombinations/recipe/CraftablePotionCombinationCraftingRecipe.java
@@ -4,6 +4,7 @@ import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.nbt.NbtInt;
 import net.minecraft.potion.PotionUtil;
 import net.minecraft.recipe.RecipeSerializer;
 import net.minecraft.recipe.SpecialCraftingRecipe;
@@ -30,12 +31,27 @@ public class CraftablePotionCombinationCraftingRecipe extends SpecialCraftingRec
     @Override
     public ItemStack craft(CraftingInventory inventory) {
         List<StatusEffectInstance> statusEffects = new ArrayList<>();
+        int colorR = 0;
+        int colorG = 0;
+        int colorB = 0;
+        int potionCount = 0;
         for (int i = 0; i < inventory.size(); i++) {
             var stack = inventory.getStack(i);
             if (stack.isEmpty()) continue;
             statusEffects.addAll(PotionUtil.getPotionEffects(stack));
+            int stackColor = PotionUtil.getColor(stack);
+            colorR += stackColor >> 16;
+            colorG += stackColor >> 8 & 0xFF;
+            colorB += stackColor & 0xFF;
+            ++potionCount;
         }
-        return PotionUtil.setCustomPotionEffects(new ItemStack(Items.POTION), statusEffects);
+        ItemStack result = PotionUtil.setCustomPotionEffects(new ItemStack(Items.POTION), statusEffects);
+        result.setSubNbt("CustomPotionColor", NbtInt.of(
+                (colorR / potionCount << 16) +
+                (colorG / potionCount << 8) +
+                (colorB / potionCount)
+        ));
+        return result;
     }
 
     @Override


### PR DESCRIPTION
There's a bug in current version that you can put something in crafting grid, then remove it, and you get free potion without effects (so free bottle basically). I fixed that.

Also made that combined potion will have an average color of its ingredients.